### PR TITLE
Add area aim for spells

### DIFF
--- a/Agents/SummonerAgentComponent.cs
+++ b/Agents/SummonerAgentComponent.cs
@@ -16,17 +16,17 @@ public class SummonerAgentComponent : AgentComponent
     public SummonerAgentComponent(Agent agent)
         : base(agent) { }
 
-    public void Summon(Agent caster, SummonSpellData data)
+    public void Summon(Agent caster, Vec3 position, SummonSpellData data)
     {
         ClearSummons();
 
         for (var i = 0; i < data.Amount; i++)
         {
-            SummonAgent(caster, data);
+            SummonAgent(caster, position, data);
         }
     }
 
-    private void SummonAgent(Agent caster, SummonSpellData data)
+    private void SummonAgent(Agent caster, Vec3 position, SummonSpellData data)
     {
         var character = MBObjectManager.Instance.GetObject<CharacterObject>(data.AgentName);
         var agent = Mission.Current.SpawnTroop(
@@ -40,7 +40,7 @@ public class SummonerAgentComponent : AgentComponent
             true,
             true,
             true,
-            caster.Position + caster.GetMovementDirection().ToVec3(1) * 3,
+            position,
             caster.GetMovementDirection()
         );
 

--- a/Data/Xml/SpellDataXml.cs
+++ b/Data/Xml/SpellDataXml.cs
@@ -29,6 +29,15 @@ namespace EOAE_Code.Data.Xml
         [XmlAttribute]
         public float Range = 0;
 
+        [XmlAttribute]
+        public float AreaRange = 0;
+
+        [XmlAttribute]
+        public bool AreaAim = false;
+
+        [XmlAttribute]
+        public string AreaAimPrefab = "";
+
         [XmlElement]
         public SummonSpellData? SummonSpellData = null;
 

--- a/Magic/Spells/Spell.cs
+++ b/Magic/Spells/Spell.cs
@@ -1,11 +1,12 @@
-﻿using EOAE_Code.Character;
-using EOAE_Code.Data.Xml;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using EOAE_Code.Character;
+using EOAE_Code.Data.Xml;
 using TaleWorlds.Core;
+using TaleWorlds.Library;
 using TaleWorlds.MountAndBlade;
 
 namespace EOAE_Code.Magic.Spells
@@ -15,20 +16,28 @@ namespace EOAE_Code.Magic.Spells
         public string Name { get; private set; }
         public string ItemName { get; private set; }
         public int Cost { get; private set; }
+        public float Range { get; private set; }
+        public float AreaRange { get; private set; }
         public SkillObject School { get; private set; }
+        public bool AreaAim { get; private set; }
+        public string AreaAimPrefab { get; private set; }
         public abstract bool IsThrown { get; }
 
-        public Spell(SpellDataXml data) 
+        public Spell(SpellDataXml data)
         {
             Name = data.Name;
             ItemName = data.ItemName;
             Cost = data.Cost;
+            Range = data.Range;
+            AreaRange = data.AreaRange;
+            AreaAim = data.AreaAim;
+            AreaAimPrefab = data.AreaAimPrefab;
 
             switch (data.SchoolName)
             {
                 case "Destruction":
                     School = CustomSkills.Instance.Destruction;
-                break;
+                    break;
                 case "Restoration":
                     School = CustomSkills.Instance.Restoration;
                     break;
@@ -42,5 +51,17 @@ namespace EOAE_Code.Magic.Spells
         }
 
         public abstract void Cast(Agent caster);
+
+        protected Vec3 GetAimedPosition(Agent caster)
+        {
+            if (AreaAim && caster.IsPlayerControlled)
+            {
+                return Mission
+                    .Current.GetMissionBehavior<MagicMissionView>()
+                    .LastAreaAimFrame.origin;
+            }
+
+            return caster.Position + caster.GetMovementDirection().ToVec3(1) * 2;
+        }
     }
 }

--- a/Magic/Spells/SummonSpell.cs
+++ b/Magic/Spells/SummonSpell.cs
@@ -31,6 +31,6 @@ public class SummonSpell : Spell
             caster.AddComponent(summonerComponent);
         }
 
-        summonerComponent.Summon(caster, _data);
+        summonerComponent.Summon(caster, GetAimedPosition(caster), _data);
     }
 }

--- a/_Module/custom_xml/spells.xml
+++ b/_Module/custom_xml/spells.xml
@@ -31,6 +31,9 @@
       Cost="25"
       Effect="Summon"
       Range="15"
+      AreaRange="3"
+      AreaAim="true"
+      AreaAimPrefab="casting_circle_prefab"
     >
       <SummonSpellData
         AgentName="sword_sisters_sister_infantry_t5"


### PR DESCRIPTION
Spells with `AreaAim` set can use `GetAimedPosition(caster)` during cast to affect a specific position/area