### PR TITLE
Add status effects for bombard spells

### DIFF
--- a/Data/Xml/BombardMissileData.cs
+++ b/Data/Xml/BombardMissileData.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Xml.Serialization;
+using EOAE_Code.Data.Xml.StatusEffects;
 
 namespace EOAE_Code.Data.Xml
 {
@@ -20,5 +21,8 @@ namespace EOAE_Code.Data.Xml
 
         [XmlAttribute]
         public float MaxHeight = 0;
+
+        [XmlElement]
+        public StatusEffectBase? StatusEffect;
     }
 }

--- a/Data/Xml/StatusEffects/StatusEffectBase.cs
+++ b/Data/Xml/StatusEffects/StatusEffectBase.cs
@@ -21,6 +21,6 @@ namespace EOAE_Code.Data.Xml.StatusEffects
 
         public abstract void Apply(float totalValue, AgentDrivenProperties multiplierProperties);
 
-        public abstract void EffectTick(float totalValue, Agent target, Agent caster); 
+        public abstract void EffectTick(float totalValue, Agent target, Agent caster);
     }
 }

--- a/Extensions/ItemObjectExtensions.cs
+++ b/Extensions/ItemObjectExtensions.cs
@@ -1,0 +1,26 @@
+﻿using System.Runtime.CompilerServices;
+using EOAE_Code.Data.Xml.StatusEffects;
+using TaleWorlds.Core;
+
+namespace EOAE_Code.Extensions;
+
+public static class ItemObjectExtensions
+{
+    private static readonly ConditionalWeakTable<ItemObject, MissileEffectHolder> _missileEffects =
+        new();
+
+    private class MissileEffectHolder
+    {
+        public StatusEffectBase StatusEffect { get; set; } = null!;
+    }
+
+    public static StatusEffectBase? GetMissileEffect(this ItemObject instance)
+    {
+        return !_missileEffects.TryGetValue(instance, out var value) ? null : value.StatusEffect;
+    }
+
+    public static void SetMissileEffect(this ItemObject instance, StatusEffectBase value)
+    {
+        _missileEffects.GetOrCreateValue(instance).StatusEffect = value;
+    }
+}

--- a/Magic/MissileSpawner.cs
+++ b/Magic/MissileSpawner.cs
@@ -1,4 +1,6 @@
-﻿using TaleWorlds.Core;
+﻿using EOAE_Code.Data.Xml.StatusEffects;
+using EOAE_Code.Extensions;
+using TaleWorlds.Core;
 using TaleWorlds.Engine;
 using TaleWorlds.Library;
 using TaleWorlds.MountAndBlade;
@@ -10,9 +12,18 @@ public class MissileSpawner : ScriptComponentBehavior
 {
     public Agent Caster { get; set; }
 
-    public void SpawnMissile(string missileName, Vec3 offset, Vec3 direction, float speed)
+    public void SpawnMissile(
+        string missileName,
+        Vec3 offset,
+        Vec3 direction,
+        float speed,
+        StatusEffectBase? statusEffect
+    )
     {
         var missileItem = MBObjectManager.Instance.GetObject<ItemObject>(missileName);
+        if (statusEffect != null)
+            missileItem.SetMissileEffect(statusEffect);
+
         var missionWeapon = new MissionWeapon(missileItem, null, null);
         var position = GameEntity.GlobalPosition + offset;
         var orientation = GameEntity.GetGlobalFrame().rotation;

--- a/Magic/Spells/BombardSpell.cs
+++ b/Magic/Spells/BombardSpell.cs
@@ -22,7 +22,6 @@ public class BombardSpell : Spell, IUseAreaAim
     public float Radius { get; private set; }
     public string AreaAimPrefab { get; private set; }
 
-
     public BombardSpell(SpellData data)
         : base(data)
     {
@@ -48,7 +47,9 @@ public class BombardSpell : Spell, IUseAreaAim
 
     public override void Cast(Agent caster)
     {
-        var playerCastFrame = caster.IsPlayerControlled ? GetAimedFrame(caster) : GetTargeting().GetBestFrame(caster, this);
+        var playerCastFrame = caster.IsPlayerControlled
+            ? GetAimedFrame(caster)
+            : GetTargeting().GetBestFrame(caster, this);
         if (playerCastFrame == MatrixFrame.Zero)
         {
             return;
@@ -62,7 +63,8 @@ public class BombardSpell : Spell, IUseAreaAim
                     _data.MissileName,
                     pos,
                     new Vec3(0.01f, 0.01f, -1),
-                    _data.MissileSpeed
+                    _data.MissileSpeed,
+                    _data.StatusEffect
                 )
             );
 

--- a/_Module/custom_xml/spells.xml
+++ b/_Module/custom_xml/spells.xml
@@ -48,7 +48,14 @@
         MissileSpeed="10"
         MinHeight="20"
         MaxHeight="100"
-      />
+      >
+        <StatusEffect
+          xsi:type="DamageOverTimeEffectData"
+          Key="burning"
+          Value="10"
+          Duration="5"
+        />
+      </Missile>
     </Bombard>
     <Bombard
       Name="{=xAhvfsnc}Arrow Volley"


### PR DESCRIPTION
I'm using `ConditionalWeakTable` here to store missile -> statusEffect relation.

I haven't used it before, but as I understand it should mitigate any kind of memory leakage (e.g. we don't want to keep storing status effect if missile was destroyed)